### PR TITLE
Add a few macros to support InverterLayer on BASALT

### DIFF
--- a/src/effect_layer.h
+++ b/src/effect_layer.h
@@ -25,3 +25,11 @@ void effect_layer_add_effect(EffectLayer *effect_layer, effect_cb* effect, void*
 
 //gets layer
 Layer* effect_layer_get_layer(EffectLayer *effect_layer);
+
+// Recreate inverter_layer for BASALT
+#ifndef PBL_PLATFORM_APLITE
+  #define InverterLayer EffectLayer
+  #define inverter_layer_create(frame)({ EffectLayer* _el=effect_layer_create(frame); effect_layer_add_effect(_el,effect_invert,NULL);_el; })
+  #define inverter_layer_get_layer effect_layer_get_layer
+  #define inverter_layer_destroy effect_layer_destroy
+#endif


### PR DESCRIPTION
Re-add support for InverterLayer in SDK3.0.
Just include effect_layer.h in files using InverterLayer and it should
work out of the box.
Warning: This InverterLayer actually invert all colors, unlike the
original InverterLayer that had a weird behavior on Basalt.